### PR TITLE
Externalizare filtrare fișiere temporare în appsettings.json

### DIFF
--- a/NfsWatcher/appsettings.json
+++ b/NfsWatcher/appsettings.json
@@ -1,6 +1,19 @@
 {
   "NfsWatcher": {
-    "WatchPath": "Z:\\"
+    "WatchPath": "Z:\\",
+    "IgnorePatterns": [
+      "^~\\$",
+      "^\\.~lock\\.",
+      "^\\.goutputstream-",
+      "\\.tmp$",
+      "\\.temp$",
+      "\\.swp$",
+      "\\.swx$",
+      "\\.bak$",
+      "\\.partial$",
+      "^\\.ds_store$",
+      "^thumbs\\.db$"
+    ]
   },
   "RabbitMq": {
     "HostName": "localhost",


### PR DESCRIPTION
Am înlocuit logica hardcodată pentru filtrarea fișierelor temporare cu una configurabilă din appsettings.json.

Am adăugat o clasă nouă (TempFileFilter) care încarcă o listă de expresii regulate din secțiunea NfsWatcher:IgnorePatterns. Aceste pattern-uri sunt compilate la pornirea aplicației și folosite pentru a exclude fișierele nedorite (ex. .tmp, ~$, etc.).

Astfel, lista de fișiere ignorate poate fi modificată fără a recompila aplicația.